### PR TITLE
Addresses further issues detailed in #2

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -79,7 +79,7 @@ MaryoGenerator.prototype.askFor = function askFor() {
         );
 
         // Prompt the user and handle the user responses
-        this.prompt(prompts, function (err, props) {
+        this.prompt(prompts, function (props, err) {
             this.styleFormat = props.styleFormat || styleFormat[0];
             this.templateFormat = props.templateFormat || templateFormat[0];
             this.testFramework = props.testFramework || testFramework[0];


### PR DESCRIPTION
This fixes that specific error, but another still gets thrown. The generator seems to finish ok. Can't say I'd know what was missing.

```
> grunt-lodashbuilder@0.1.7 postinstall /Users/adam/develop/dnd_attrs/node_modules/grunt-requirejs/node_modules/grunt-lodashbuilder
> node ./bin/post-install.js


module.js:340
    throw err;
          ^
Error: Cannot find module '../node_modules/lodash/vendor/tar/tar.js'
    at Function.Module._resolveFilename (module.js:338:15)
    at Function.Module._load (module.js:280:25)
    at Module.require (module.js:364:17)
    at require (module.js:380:17)
    at /Users/adam/develop/dnd_attrs/node_modules/grunt-requirejs/node_modules/grunt-lodashbuilder/bin/post-install.js:14:13
    at Object.<anonymous> (/Users/adam/develop/dnd_attrs/node_modules/grunt-requirejs/node_modules/grunt-lodashbuilder/bin/post-install.js:166:2)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
```
