### PR TITLE
npm scripts support and list prompts

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -32,6 +32,7 @@ MaryoGenerator.prototype.askFor = function askFor() {
         fs.readFile(path, function (err, data) {
             var config = JSON.parse(data);
 
+            this.taskFormat = config.taskFormat;
             this.styleFormat = config.styleFormat;
             this.templateFormat = config.templateFormat;
             this.testFramework = config.testFramework;
@@ -41,26 +42,43 @@ MaryoGenerator.prototype.askFor = function askFor() {
         }.bind(this));
     } else {
         var styleFormat = ['css', 'sass', 'less'],
+            modulesFormat = ['RequireJS', 'Webpack'],
+            taskFormat = ['npmscripts', 'grunt'],
             templateFormat = ['_', 'dust'],
             testFramework = ['none', 'jasmine', 'mocha'],
             prompts = [{
+                name: 'moduleFormat',
+                message: 'Choose a module bundler:',
+                type: 'list',
+                choices: modulesFormat,
+                store: true
+            }, {
+                name: 'taskFormat',
+                message: 'Which task runner would you like to use (' + taskFormat.join("/") + ')?',
+                type: 'list',
+                choices: taskFormat
+            }, {
                 name: 'styleFormat',
-                message: 'Which style format would you like to use ('+styleFormat.join("/")+')?',
+                message: 'Which style format would you like to use (' + styleFormat.join("/") + ')?',
+                type: 'list',
                 choices: styleFormat
             },
             {
                 name: 'templateFormat',
-                message: 'Which template library would you like to use ('+templateFormat.join("/")+')?',
+                message: 'Which template library would you like to use (' + templateFormat.join("/") + ')?',
+                default: '_',
                 choices: templateFormat
             },
             {
                 name: 'testFramework',
-                message: 'Which test framework would you like to use ('+testFramework.join("/")+')?',
+                message: 'Which test framework would you like to use (' + testFramework.join("/") + ')?',
+                type: 'list',
                 choices: testFramework
             },
             {
                 name: 'includeBootstrap',
                 message: 'Would you like to include Bootstrap (y)?',
+                default: 'y',
                 type: 'confirm'
             }];
 
@@ -81,6 +99,7 @@ MaryoGenerator.prototype.askFor = function askFor() {
         // Prompt the user and handle the user responses
         this.prompt(prompts, function (props, err) {
             this.styleFormat = props.styleFormat || styleFormat[0];
+            this.taskFormat = props.taskFormat || taskFormat[0];
             this.templateFormat = props.templateFormat || templateFormat[0];
             this.testFramework = props.testFramework || testFramework[0];
             this.includeBootstrap = props.includeBootstrap;
@@ -120,6 +139,7 @@ MaryoGenerator.prototype.app = function app () {
     this.copy('app.js', 'app/scripts/app.js');
     this.copy('main.js', 'app/scripts/main.js');
     this.copy('index.html', 'app/index.html');
+    this.write('app/styles/styles.' + this.styleFormat, '');
     this.copy('editorconfig', '.editorconfig');
     this.copy('jshintrc', '.jshintrc');
     this.copy('gitattributes', '.gitattributes');

--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -2,7 +2,7 @@
   "name": "<%= _.slugify(appname) %>",
   "version": "0.0.0",
   "dependencies": {},
-  "devDependencies": {
+  "devDependencies": {<% if (this.taskFormat === 'grunt') { %>
     "grunt": "~0.4.1",
     "grunt-contrib-copy": "~0.4.1",
     "grunt-contrib-concat": "~0.3.0",
@@ -21,7 +21,7 @@
     "grunt-mocha": "~0.3.0",<% } %>
     "grunt-requirejs": "~0.4.0",
     "grunt-bower-requirejs": "~0.4.3",<% if (templateFormat === 'dust') { %>
-    "grunt-dustjs": "~1.1.1", <% } if (templateFormat === 'handlebars') { %>
+    "grunt-dustjs": "~1.1.1",<% } if (templateFormat === 'handlebars') { %>
     "grunt-contrib-handlebars": "~0.5.8",
     "Backbone.Marionette.Handlebars": "0.2.0",<% } if (templateFormat === '_') { %>
     "grunt-contrib-jst": "0.5.0",<% } %>
@@ -30,8 +30,27 @@
     "grunt-open": "~0.2.0",
     "grunt-svgmin": "~0.1.0",
     "grunt-concurrent": "~0.1.0",
-    "matchdep": "~0.1.1"
-  },
+    "matchdep": "~0.1.1"<% } %><% if (taskFormat === 'npmscripts') { if (styleFormat === 'sass') { %>
+    "del-cli": "^0.2.0",
+    "node-sass": "^3.4.2",
+    "postcss-cli": "^2.5.1",
+    "autoprefixer": "^6.3.3",
+    "postcss-flexboxfixer": "0.0.4",
+    "cssnano": "^3.5.2"<% } else if (styleFormat === 'less') { %>
+    "less": "^2.6.1",
+    "less-watch-compiler": "^1.2.3",
+    "less-plugin-autoprefix": "^1.5.1"<% } } %>
+  },<% if (taskFormat === 'npmscripts') { %>
+  "scripts": { <% if (styleFormat === 'sass') { %>
+    "scss": "npm run scss:clean && node-sass app/styles -o app/styles --source-map true --output-style expanded --source-comments true",
+    "scss:watch": "npm run scss && node-sass app/styles -o app/styles --source-map true --output-style expanded --source-comments true --watch -r app/styles",
+    "scss:prod": "npm run scss:clean && node-sass app/styles -o app/styles --output-style compressed && npm run scss:final",
+    "scss:final": "postcss -u autoprefixer -u postcss-flexboxfixer -u cssnano --config ops.json -r app/styles/*.css",<% } else if (styleFormat === 'less') { %>
+    "scss": "npm run scss:clean && lessc app/styles/styles.less app/styles/styles.css",
+    "scss:watch": "npm run scss && less-watch-compiler app/styles app/styles styles.less",
+    "scss:prod": "npm run scss:clean && lessc -x --autoprefix='last 2 versions' app/styles -o app/styles --output-style",<% } %>
+    "scss:clean": "del-cli --force app/styles/styles.css"
+  },<% } %>
   "engines": {
     "node": ">=0.8.0"
   }


### PR DESCRIPTION
Added support for using npm scripts. Only css support is available in
this commit, but more are to follow.

Improved prompt management by using the list type attribute for most
multiple choice prompts to avoid spelling issues.