### PR TITLE
Include requirejs-text

### DIFF
--- a/app/templates/_bower.json
+++ b/app/templates/_bower.json
@@ -2,7 +2,8 @@
   "name": "<%= _.slugify(appname) %>",
   "version": "0.0.0",
   "dependencies": {
-    "requirejs": "~2.2.0",<% if (includeBootstrap) { %>
+    "requirejs": "^2.2.20",
+    "requirejs-text": "^2.0.12",<% if (includeBootstrap) { %>
     "bootstrap": "~3.3.6",<% } %>
     "marionette": "~2.4.5",
     "backbone.wreqr": "1.3.6",


### PR DESCRIPTION
Useful for serving templates as requirejs modules. Can also be used to store a hash of compiled templates.