### PR TITLE
Updated RequireJS ver and removed WebPack menu option

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -46,13 +46,13 @@ MaryoGenerator.prototype.askFor = function askFor() {
             taskFormat = ['npmscripts', 'grunt'],
             templateFormat = ['_', 'dust'],
             testFramework = ['none', 'jasmine', 'mocha'],
-            prompts = [{
+            prompts = [/*{ // TODO: ADD WebPack support
                 name: 'moduleFormat',
                 message: 'Choose a module bundler:',
                 type: 'list',
                 choices: modulesFormat,
                 store: true
-            }, {
+            },*/ {
                 name: 'taskFormat',
                 message: 'Which task runner would you like to use (' + taskFormat.join("/") + ')?',
                 type: 'list',

--- a/app/templates/_bower.json
+++ b/app/templates/_bower.json
@@ -2,7 +2,7 @@
   "name": "<%= _.slugify(appname) %>",
   "version": "0.0.0",
   "dependencies": {
-    "requirejs": "^2.2.20",
+    "requirejs": "^2.1.20",
     "requirejs-text": "^2.0.12",<% if (includeBootstrap) { %>
     "bootstrap": "~3.3.6",<% } %>
     "marionette": "~2.4.5",
@@ -11,8 +11,8 @@
     "lodash": ">=3.0.0 <4.0.0",
     "jquery": "~2.2.3",<% if (templateFormat === 'dust') { %>
     "dustjs-linkedin": "2.7.2",
-    "dustjs-linkedin-helpers": "1.7.3",<% } %>
-    "marionette-dust": "0.3.3"
+    "dustjs-linkedin-helpers": "1.7.3",
+    "marionette-dust": "0.3.3" <% } %>
   },
   "devDependencies": {
 

--- a/app/templates/_bower.json
+++ b/app/templates/_bower.json
@@ -2,7 +2,7 @@
   "name": "<%= _.slugify(appname) %>",
   "version": "0.0.0",
   "dependencies": {
-    "requirejs": "^2.1.20",
+    "requirejs": "^2.2.0",
     "requirejs-text": "^2.0.12",<% if (includeBootstrap) { %>
     "bootstrap": "~3.3.6",<% } %>
     "marionette": "~2.4.5",


### PR DESCRIPTION
bower.json was pointing to latest GitHub ver. However bower.json points to the jburke fork. Changed RequireJS version to comply with the bower repo version.

I am planning to add WebPack support (someday) and had added a menu option to choose a bundler. Since we still only support RequireJS I removed the menu prompt.